### PR TITLE
Fix issue#8, fold data into different rows when its size is more than MAX_TEXTURE_SIZE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ jobs:
         email: "donghao.ren+npm@gmail.com"
         api_key:
           secure: "VNkn7xYuSLkgJ0VmvzxFaI6Nx+uzheiMjW3V7nT/lMKOMNvLbCkWgAxZ+qZWgVKHhJZlEFGdhJUtbkr5ATQNZW5cZ+ehyx9eoJjEYicvt/r9nqRb7mGuAM+WHEe7oRIn7A+vgYnYr4hITz03+rSbkOQO4uGW5K1Yf3fhBrR5f1mVFiWL0/4Ad8C19C2Xa2q8U3qmppGGA1MIr+iMCOgryoGLriNFbSm7nqMU2HOdZRTRpcbAzSiQGOi5mTu9jieBBJxScDAuHkL2S4MZQZAEYL02C1YpmZ1ktsMZwWuU0/BXSXroSU9HTBuPvcrLpZB82dzcs2Hxd4JaDH6BnbZy0cjh0xAeDDWsdR3CuksOF8ag33mkRReJBNbxLhlouCLClFEf8EcHkbgDhasZYDUGOikzF49+xZIh0vo/wlzO1MH0oPXWiD5IetOSfFNiS7uAsQStkl3pANvAGGFtdEUFaGknqQKInlgqaTm559HYhQK9otisGh0Upn7o+DGtepnFpM5EmzstiuQG9J/WyaYZnr2Z4y9Zf8YW+7hNTeS9ELyY4EeTFhK/3rvc39/oGM7gMHffT12qFZORw+ynCoDJDvBckY5ysRRDd2pw/A3K54N2kHc4KN9sQKKqohrr/B23WGl4mT0RngxgopP1Ho2wg+gc1owU12ZB5PC/qB4KMzg="
+        on:
+          tags: true
     - stage: deploy stardust-webgl
       if: branch =~ /^stardust-webgl-.*$/
       before_deploy: cd packages/stardust-webgl
@@ -49,6 +51,8 @@ jobs:
         email: "donghao.ren+npm@gmail.com"
         api_key:
           secure: "VNkn7xYuSLkgJ0VmvzxFaI6Nx+uzheiMjW3V7nT/lMKOMNvLbCkWgAxZ+qZWgVKHhJZlEFGdhJUtbkr5ATQNZW5cZ+ehyx9eoJjEYicvt/r9nqRb7mGuAM+WHEe7oRIn7A+vgYnYr4hITz03+rSbkOQO4uGW5K1Yf3fhBrR5f1mVFiWL0/4Ad8C19C2Xa2q8U3qmppGGA1MIr+iMCOgryoGLriNFbSm7nqMU2HOdZRTRpcbAzSiQGOi5mTu9jieBBJxScDAuHkL2S4MZQZAEYL02C1YpmZ1ktsMZwWuU0/BXSXroSU9HTBuPvcrLpZB82dzcs2Hxd4JaDH6BnbZy0cjh0xAeDDWsdR3CuksOF8ag33mkRReJBNbxLhlouCLClFEf8EcHkbgDhasZYDUGOikzF49+xZIh0vo/wlzO1MH0oPXWiD5IetOSfFNiS7uAsQStkl3pANvAGGFtdEUFaGknqQKInlgqaTm559HYhQK9otisGh0Upn7o+DGtepnFpM5EmzstiuQG9J/WyaYZnr2Z4y9Zf8YW+7hNTeS9ELyY4EeTFhK/3rvc39/oGM7gMHffT12qFZORw+ynCoDJDvBckY5ysRRDd2pw/A3K54N2kHc4KN9sQKKqohrr/B23WGl4mT0RngxgopP1Ho2wg+gc1owU12ZB5PC/qB4KMzg="
+        on:
+          tags: true
     - stage: deploy stardust-isotype
       if: branch =~ /^stardust-isotype-.*$/
       before_deploy: cd packages/stardust-isotype
@@ -58,3 +62,5 @@ jobs:
         email: "donghao.ren+npm@gmail.com"
         api_key:
           secure: "VNkn7xYuSLkgJ0VmvzxFaI6Nx+uzheiMjW3V7nT/lMKOMNvLbCkWgAxZ+qZWgVKHhJZlEFGdhJUtbkr5ATQNZW5cZ+ehyx9eoJjEYicvt/r9nqRb7mGuAM+WHEe7oRIn7A+vgYnYr4hITz03+rSbkOQO4uGW5K1Yf3fhBrR5f1mVFiWL0/4Ad8C19C2Xa2q8U3qmppGGA1MIr+iMCOgryoGLriNFbSm7nqMU2HOdZRTRpcbAzSiQGOi5mTu9jieBBJxScDAuHkL2S4MZQZAEYL02C1YpmZ1ktsMZwWuU0/BXSXroSU9HTBuPvcrLpZB82dzcs2Hxd4JaDH6BnbZy0cjh0xAeDDWsdR3CuksOF8ag33mkRReJBNbxLhlouCLClFEf8EcHkbgDhasZYDUGOikzF49+xZIh0vo/wlzO1MH0oPXWiD5IetOSfFNiS7uAsQStkl3pANvAGGFtdEUFaGknqQKInlgqaTm559HYhQK9otisGh0Upn7o+DGtepnFpM5EmzstiuQG9J/WyaYZnr2Z4y9Zf8YW+7hNTeS9ELyY4EeTFhK/3rvc39/oGM7gMHffT12qFZORw+ynCoDJDvBckY5ysRRDd2pw/A3K54N2kHc4KN9sQKKqohrr/B23WGl4mT0RngxgopP1Ho2wg+gc1owU12ZB5PC/qB4KMzg="
+        on:
+          tags: true

--- a/packages/stardust-webgl/src/webgl/webgl.ts
+++ b/packages/stardust-webgl/src/webgl/webgl.ts
@@ -121,7 +121,7 @@ class WebGLPlatformMarkProgram {
       this.setUniform(name, types.int, unit);
     }
     const cache = this._textures.get(name);
-    const newData = texture.getTextureData();
+    const newData = texture.getTextureData(GL);
     if (cache.data == newData) {
       return;
     } else {


### PR DESCRIPTION
For the [graph example](https://stardustjs.github.io/examples/graph/), when visualizing a graph with more than MAX_TEXTURE_SIZE (it may be 2^14 or 2^15), webGL will report that: `WebGL: INVALID_VALUE: texImage2D: width or height out of range`.
Now, the data is bound to texture with one row (`newData.width = data.length; newData.height = 1`), when the length of data exceeds the MAX_TEXTURE_SIZE, it will not be visualized.
I fold the data into several rows in the texture (`newData.width = data.length > MAX_TEXTURE_SIZE ? MAX_TEXTURE_SIZE : data.length; newData.height = Math.ceil(data.length / MAX_TEXTURE_SIZE)`), so that its length will not exceed the MAX_TEXTURE_SIZE.